### PR TITLE
SubscribersMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and subscription settings as the value.
 - `Storage` `addSubscriber` takes a `SubscriptionMap` as the second parameter
   instead of an array of the old `Subscription` type.
+- `Sink` is now typed by the message-type it accepts.
 
 ## [0.0.4] - 2019-05-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `stateNewData` event on `StateInstance` will now use `T` as the type
   for the state-data.
 - `crustate/react` now uses named imports from `react`.
+- `State` `subscriptions` is renamed to `subscribe`
+- `State` now subscribes using a dictionary with message key-names as the key
+  and subscription settings as the value.
+- `Storage` `addSubscriber` takes a `SubscriptionMap` as the second parameter
+  instead of an array of the old `Subscription` type.
 
 ## [0.0.4] - 2019-05-14
 ### Fixed
@@ -32,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.2] - 2019-05-10
 ### Added
 - Added license file, MIT, same as `package.json` already specifies.
-- Added `messageMatched` events when subscribers on `Storage` match messages.
+- Added `messageMatched` events when subscriptions on `Storage` match messages.
 - Added an optional parameter of `sourceName` to `sendMessage` which is appended
   to the source-path, this parameter defaults to the anonymous source "`$`".
 - Added TodoMVC Example

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ with controlled side-effects through messaging.
 
 ```javascript
 type State<T, I, M: Message> = {
-  name: string,
-  init: (init: I) => DataUpdate<T> | MessageUpdate<T>,
-  update: (state: T, msg: M) => Update<T>,
-  subscriptions: (state: T) => Array<Subscription>,
+  name:      string,
+  init:      (init: I)          => DataUpdate<T> | MessageUpdate<T>,
+  update:    (state: T, msg: M) => Update<T>,
+  subscribe: (state: T)         => SubscriberMap<M>,
 };
 ```
 
@@ -50,10 +50,26 @@ let msg = {
 };
 ```
 
+### Init
+
+```javascript
+type StateInit<T, I> = (init: I) => DataUpdate<T> | MessageUpdate<T>;
+```
+
+The initial state of the state-instance, accepts an optional init-parameter.
+
+```javascript
+import { updateData } from "crustate";
+
+function init() {
+  return updateData(0);
+}
+```
+
 ### Update
 
 ```javascript
-type StateUpdate = <T, M: Message>(state: T, msg: M) => Update<T>;
+type StateUpdate<T, M: Message> = (state: T, msg: M) => Update<T>;
 ```
 
 Conceptually `update` is responsible for receiving messages, interpreting
@@ -64,7 +80,7 @@ This is very similar to Redux's Reducer concept with the main difference
 being that the `update`-function can send new messages.
 
 ```javascript
-import { NONE, updateData } from "crustate";
+import { NONE } from "crustate";
 
 function update(state, message) {
   switch(message.tag) {
@@ -81,7 +97,24 @@ state-hierarchy and can be subscribed to in supervising states.
 
 ### Subscriber
 
+```javascript
+type Subscribe<T, M: Message>    = (state: T) => SubscriberMap<M>;
+type SubscriptionMap<M: Message> = { [tag: $PropertyType<M, "tag">]: Subscription };
+type Subscription                = true | { passive?: boolean, filter?: () => bool };
+```
+
 For a state to actually receive messages it first needs to subscribe to
 messages; which tags it is interested in, if they have any specific
-requirements, and if it is supposed to be the primary handler for messages
-of that type.
+requirements, and if it is supposed to be the primary (active) handler for
+messages of that type.
+
+```javascript
+function subscribe(state) {
+  return {
+    [ADD]: true,
+  };
+}
+```
+
+By default subscriptions are active but can be turned into passive subscriptions
+by specifying the `passive` flag.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ type State<T, I, M: Message> = {
   name:      string,
   init:      (init: I)          => DataUpdate<T> | MessageUpdate<T>,
   update:    (state: T, msg: M) => Update<T>,
-  subscribe: (state: T)         => SubscriberMap<M>,
+  subscribe: (state: T)         => SubscriptionMap<M>,
 };
 ```
 
@@ -98,7 +98,7 @@ state-hierarchy and can be subscribed to in supervising states.
 ### Subscriber
 
 ```javascript
-type Subscribe<T, M: Message>    = (state: T) => SubscriberMap<M>;
+type Subscribe<T, M: Message>    = (state: T) => SubscriptionMap<M>;
 type SubscriptionMap<M: Message> = { [tag: $PropertyType<M, "tag">]: Subscription };
 type Subscription                = true | { passive?: boolean, filter?: () => bool };
 ```

--- a/build/exports/crustate.js
+++ b/build/exports/crustate.js
@@ -40,6 +40,6 @@ var removeSubscriber;
 var replyMessage;
 var sendMessage;
 var stateDefinition;
-var subscribers;
+var subscribe;
 var subscriptions;
 var tryRegisterState;

--- a/build/externs/crustate.js
+++ b/build/externs/crustate.js
@@ -42,7 +42,7 @@ crustate.StateDefinition.prototype.update = function(state, message) {};
 /**
  * @public
  */
-crustate.StateDefinition.prototype.subscriptions = function(state) {};
+crustate.StateDefinition.prototype.subscribe = function(state) {};
 
 crustate.NONE = 0;
 crustate.updateData = function(data) {};
@@ -77,7 +77,7 @@ crustate.Storage.prototype.sendMessage;
   /**
    * @export
    */
-crustate.Storage.prototype.addSubscriber;
+crustate.Storage.prototype.addSubscriber = function(listener, subscription) {};
 crustate.Storage.prototype.getNested;
 crustate.Storage.prototype.getNestedOrCreate = function(state, params) {};
 crustate.Storage.prototype.getPath;

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 import { NONE
        , updateData
-       , subscribe
        , Storage } from "crustate";
 import { StorageProvider
        , useData
@@ -26,10 +25,10 @@ const CounterData = createStateData({
 
     return NONE;
   },
-  subscriptions: (state) => state < 0 ? [] : [
-    subscribe(INCREMENT),
-    subscribe(DECREMENT),
-  ],
+  subscriptions: (state) => state < 0 ? {} : {
+    [INCREMENT]: true,
+    [DECREMENT]: true,
+  },
 });
 
 function TheCounter() {

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -25,7 +25,7 @@ const CounterData = createStateData({
 
     return NONE;
   },
-  subscriptions: (state) => state < 0 ? {} : {
+  subscribe: (state) => state < 0 ? {} : {
     [INCREMENT]: true,
     [DECREMENT]: true,
   },

--- a/examples/todomvc/src/states/filter.js
+++ b/examples/todomvc/src/states/filter.js
@@ -33,8 +33,8 @@ export const todoFilterPredicate = (filter: Filter) => (todo: Todo) => {
 export const setFilter = (value: Filter) => ({ tag: SET, value});
 
 export const FilterState = createStateData<Filter, {}, FilterMsg>({
-  name: "filter",
-  init: () => updateData(SHOW_ALL),
-  update: (_, msg) => updateData(msg.value),
-  subscriptions: () => ({ [SET]: true })
+  name:      "filter",
+  init:      ()       => updateData(SHOW_ALL),
+  update:    (_, msg) => updateData(msg.value),
+  subscribe: ()       => ({ [SET]: true })
 });

--- a/examples/todomvc/src/states/filter.js
+++ b/examples/todomvc/src/states/filter.js
@@ -4,10 +4,9 @@ import type { Todo } from "./todos";
 
 import { createStateData } from "crustate/react";
 import { NONE
-       , updateData
-       , subscribe } from "crustate";
+       , updateData } from "crustate";
 
-const SET = "filterSet";
+const SET: "filterSet" = "filterSet";
 
 export const SHOW_ACTIVE    = "ACTIVE";
 export const SHOW_ALL       = "ALL";
@@ -37,5 +36,5 @@ export const FilterState = createStateData<Filter, {}, FilterMsg>({
   name: "filter",
   init: () => updateData(SHOW_ALL),
   update: (_, msg) => updateData(msg.value),
-  subscriptions: () => [ subscribe(SET) ],
+  subscriptions: () => ({ [SET]: true })
 });

--- a/examples/todomvc/src/states/todos.js
+++ b/examples/todomvc/src/states/todos.js
@@ -2,8 +2,7 @@
 
 import { createStateData } from "crustate/react";
 import { NONE
-       , updateData
-       , subscribe } from "crustate";
+       , updateData } from "crustate";
 
 export type Todo = {
   id:        number,
@@ -58,12 +57,12 @@ export const TodosState = createStateData<Array<Todo>, {}, TodoMsg>({
 
     return NONE;
   },
-  subscriptions: () => [
-    subscribe(ADD),
-    subscribe(EDIT),
-    subscribe(REMOVE),
-    subscribe(CLEAR_ALL),
-    subscribe(COMPLETE),
-    subscribe(COMPLETE_ALL),
-  ],
+  subscriptions: () => ({
+    [ADD]: true,
+    [EDIT]: true,
+    [REMOVE]: true,
+    [CLEAR_ALL]: true,
+    [COMPLETE]: true,
+    [COMPLETE_ALL]: true,
+  }),
 });

--- a/examples/todomvc/src/states/todos.js
+++ b/examples/todomvc/src/states/todos.js
@@ -10,12 +10,12 @@ export type Todo = {
   completed: boolean,
 };
 
-const ADD          = "todosAdd";
-const EDIT         = "todosEdit";
-const REMOVE       = "todosRemove";
-const CLEAR_ALL    = "todosClearAll";
-const COMPLETE     = "todosComplete";
-const COMPLETE_ALL = "todosCompleteAll";
+const ADD          : "todosAdd"         = "todosAdd";
+const EDIT         : "todosEdit"        = "todosEdit";
+const REMOVE       : "todosRemove"      = "todosRemove";
+const CLEAR_ALL    : "todosClearAll"    = "todosClearAll";
+const COMPLETE     : "todosComplete"    = "todosComplete";
+const COMPLETE_ALL : "todosCompleteAll" = "todosCompleteAll";
 
 type TodoMsg =
   | { tag: typeof ADD, text: string }
@@ -57,7 +57,7 @@ export const TodosState = createStateData<Array<Todo>, {}, TodoMsg>({
 
     return NONE;
   },
-  subscriptions: () => ({
+  subscribe: () => ({
     [ADD]: true,
     [EDIT]: true,
     [REMOVE]: true,

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export type {
   Message,
   MessageTag,
   MessageFilter,
+  SubscriberMap,
   Subscription,
 } from "./message";
 export type {
@@ -31,9 +32,6 @@ export type {
   StateSnapshot,
 } from "./storage";
 
-export {
-  subscribe,
-} from "./message";
 export {
   NONE,
   updateData,

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export type {
   Message,
   MessageTag,
   MessageFilter,
-  SubscriberMap,
+  SubscriptionMap,
   Subscription,
 } from "./message";
 export type {
@@ -22,7 +22,7 @@ export type {
 export type {
   Init,
   StateUpdate,
-  Subscriptions,
+  Subscribe,
   State,
   StatePath,
 } from "./state";

--- a/src/message.js
+++ b/src/message.js
@@ -37,17 +37,22 @@ export type InflightMessage = {
 // TODO: Can we filter messages better?
 export type MessageFilter = (msg: Message) => boolean;
 
+/**
+ * A restricted map of message-key -> subscription-options for a given
+ * message-type.
+ */
 export type SubscriberMap<M: Message> = {
   [tag: $PropertyType<M, "tag">]: Subscription,
 };
 
 /**
- * A filter identifying messages a State can respond to.
+ * Options for a given subcription, the value true means default values for all
+ * options.
  */
 export type Subscription = true | {
   /**
    * If the Subscription is passive it will not consume the message and it will
-   * also not count towards the message being handled.
+   * also not count towards the message being handled, default is false.
    *
    * Suitable for things which are to observe the state-changes for of other
    * states.
@@ -56,7 +61,7 @@ export type Subscription = true | {
   /**
    * Extra, user-supplied, filtering logic.
    */
-  filter?: MessageFilter | null,
+  filter?: MessageFilter,
 };
 
 /**

--- a/src/message.js
+++ b/src/message.js
@@ -41,7 +41,7 @@ export type MessageFilter = (msg: Message) => boolean;
  * A restricted map of message-key -> subscription-options for a given
  * message-type.
  */
-export type SubscriberMap<M: Message> = {
+export type SubscriptionMap<M: Message> = {
   [tag: $PropertyType<M, "tag">]: Subscription,
 };
 
@@ -69,7 +69,7 @@ export type Subscription = true | {
  * @param {!crustate.Message} message
  * @param {!boolean} received
  */
-export function findMatchingSubscription<M: Message>(subscribers: SubscriberMap<M>, message: Message, received: bool): ?{ isPassive: boolean } {
+export function findMatchingSubscription<M: Message>(subscribers: SubscriptionMap<M>, message: Message, received: bool): ?{ isPassive: boolean } {
   const { tag } = message;
 
   if( ! subscribers[tag]) {
@@ -77,10 +77,10 @@ export function findMatchingSubscription<M: Message>(subscribers: SubscriberMap<
   }
 
   const subscriber = subscribers[tag];
-  const passive    = subscriber === true ? false : !!subscriber.passive;
-  const filter     = subscriber === true ? null  : subscriber.filter;
+  // const passive    = subscriber === true ? false : !!subscriber.passive;
+  // const filter     = subscriber === true ? null  : subscriber.filter;
 
-  // const { passive = false, filter } = typeof subscribers[tag] === "object" ? subscribers[tag] : { passive: false, filter: null };
+  const { passive = false, filter } = typeof subscriber === "object" ? subscriber : { passive: false, filter: null };
 
   if((passive || ! received) && tag === message.tag && ( ! filter || filter(message))) {
     return { isPassive: passive };

--- a/src/message.js
+++ b/src/message.js
@@ -37,15 +37,14 @@ export type InflightMessage = {
 // TODO: Can we filter messages better?
 export type MessageFilter = (msg: Message) => boolean;
 
+export type SubscriberMap<M: Message> = {
+  [tag: $PropertyType<M, "tag">]: Subscription,
+};
+
 /**
  * A filter identifying messages a State can respond to.
  */
-export opaque type Subscription = {
-  /**
-   * The message tag to subscribe to.
-   */
-  // TODO: Can we (or should we) merge this with the `matcher` in a subscribe constructor?
-  tag:     MessageTag,
+export type Subscription = true | {
   /**
    * If the Subscription is passive it will not consume the message and it will
    * also not count towards the message being handled.
@@ -53,38 +52,34 @@ export opaque type Subscription = {
    * Suitable for things which are to observe the state-changes for of other
    * states.
    */
-  passive: boolean,
+  passive?: boolean,
   /**
    * Extra, user-supplied, filtering logic.
    */
-  filter: MessageFilter | null,
+  filter?: MessageFilter | null,
 };
 
-// TODO: Avoid the boolean parameter
-export function subscribe(tag: MessageTag, passive: boolean = false, filter: MessageFilter | null = null): Subscription {
-  return {
-    tag,
-    passive,
-    filter,
-  };
-}
-
 /**
- * @param {!Object} subscription
+ * @param {!Object} subscribers
  * @param {!crustate.Message} message
  * @param {!boolean} received
  */
-export function subscriptionMatches(subscription: Subscription, message: Message, received: bool): boolean {
-  const { tag, passive, filter } = subscription;
+export function findMatchingSubscription<M: Message>(subscribers: SubscriberMap<M>, message: Message, received: bool): ?{ isPassive: boolean } {
+  const { tag } = message;
 
-  return (passive || ! received)
-      && tag === message.tag
-      && ( ! filter || filter(message));
-}
+  if( ! subscribers[tag]) {
+    return null;
+  }
 
-/**
- * Internal
- */
-export function subscriptionIsPassive({ passive }: Subscription): boolean {
-  return passive;
+  const subscriber = subscribers[tag];
+  const passive    = subscriber === true ? false : !!subscriber.passive;
+  const filter     = subscriber === true ? null  : subscriber.filter;
+
+  // const { passive = false, filter } = typeof subscribers[tag] === "object" ? subscribers[tag] : { passive: false, filter: null };
+
+  if((passive || ! received) && tag === message.tag && ( ! filter || filter(message))) {
+    return { isPassive: passive };
+  }
+
+  return null;
 }

--- a/src/message.js
+++ b/src/message.js
@@ -77,10 +77,10 @@ export function findMatchingSubscription<M: Message>(subscribers: SubscriptionMa
   }
 
   const subscriber = subscribers[tag];
-  // const passive    = subscriber === true ? false : !!subscriber.passive;
-  // const filter     = subscriber === true ? null  : subscriber.filter;
-
-  const { passive = false, filter } = typeof subscriber === "object" ? subscriber : { passive: false, filter: null };
+  // We do not use object destructuring here since it would require us to
+  // create a new object for the default value in the case of true
+  const passive    = subscriber === true ? false : !!subscriber.passive;
+  const filter     = subscriber === true ? null  : subscriber.filter;
 
   if((passive || ! received) && tag === message.tag && ( ! filter || filter(message))) {
     return { isPassive: passive };

--- a/src/state.js
+++ b/src/state.js
@@ -7,7 +7,7 @@ import type { InflightMessage
             , Message
             , MessageFilter
             , MessageTag } from "./message";
-import type { Subscription } from "./message";
+import type { SubscriberMap } from "./message";
 
 export type StatePath = Array<string>;
 
@@ -23,7 +23,7 @@ export type StateUpdate<T, M> = (state: T, msg: M) => Update<T>;
 /**
  * A list of subscriptions
  */
-export type Subscriptions<T> = (state: T) => Array<Subscription>;
+export type Subscriptions<T, M> = (state: T) => SubscriberMap<M>;
 
 /**
  * Definition of a state containing the data `T` which can be instantiated given
@@ -33,5 +33,5 @@ export type State<T, I, M> = {
   name:          string,
   init:          Init<T, I>,
   update:        StateUpdate<T, M>,
-  subscriptions: Subscriptions<T>,
+  subscriptions: Subscriptions<T, M>,
 };

--- a/src/state.js
+++ b/src/state.js
@@ -7,12 +7,13 @@ import type { InflightMessage
             , Message
             , MessageFilter
             , MessageTag } from "./message";
-import type { SubscriberMap } from "./message";
+import type { SubscriptionMap } from "./message";
 
 export type StatePath = Array<string>;
 
 /**
- * Initialization function, called when the initial data is loaded into the state.
+ * Initialization function, called when the initial data is loaded into the
+ * state.
  */
 export type Init<T, I> = (init: I) => DataUpdate<T> | MessageUpdate<T>;
 /**
@@ -21,17 +22,18 @@ export type Init<T, I> = (init: I) => DataUpdate<T> | MessageUpdate<T>;
  */
 export type StateUpdate<T, M> = (state: T, msg: M) => Update<T>;
 /**
- * A list of subscriptions
+ * A function returning a dictionary of subscriptions the state is interested
+ * in.
  */
-export type Subscriptions<T, M> = (state: T) => SubscriberMap<M>;
+export type Subscribe<T, M> = (state: T) => SubscriptionMap<M>;
 
 /**
  * Definition of a state containing the data `T` which can be instantiated given
  * the initial data `I`.
  */
 export type State<T, I, M> = {
-  name:          string,
-  init:          Init<T, I>,
-  update:        StateUpdate<T, M>,
-  subscriptions: Subscriptions<T, M>,
+  name:      string,
+  init:      Init<T, I>,
+  update:    StateUpdate<T, M>,
+  subscribe: Subscribe<T, M>,
 };

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,14 +4,13 @@ import type { State
             , StatePath } from "./state";
 import type { InflightMessage
             , Message
-            , Subscription } from "./message";
+            , SubscriberMap } from "./message";
 
 import { updateHasData
        , updateStateData
        , updateStateDataNoNone
        , updateOutgoingMessages } from "./update";
-import { subscriptionIsPassive
-       , subscriptionMatches } from "./message";
+import { findMatchingSubscription } from "./message";
 import { EventEmitter } from "./eventemitter";
 
 const ANONYMOUS_SOURCE = "$";
@@ -52,8 +51,8 @@ export type StateSnapshot = {
  */
 export type Supervisor = Storage | StateInstance<any, any, any>;
 
-export type Sink = (message: Message, sourcePath: StatePath) => mixed;
-export type Subscribers = Array<{ listener: Sink, filter: Array<Subscription> }>;
+export type Sink<M: Message> = (message: M, sourcePath: StatePath) => mixed;
+export type Subscriber<M: Message> = { listener: Sink<M>, filter: SubscriberMap<M> };
 
 export type StateInstanceMap = { [name:string]: StateInstance<any, any, any> };
 
@@ -121,7 +120,7 @@ export type StorageEvents = {
  * Base node in a state-tree, anchors all states and carries all data.
  */
 export class Storage extends EventEmitter<StorageEvents> implements AbstractSupervisor {
-  _subscribers: Subscribers = [];
+  _subscribers: Array<Subscriber<any>> = [];
   _nested: StateInstanceMap = {};
   /**
    * State-definitions, used for subscribers and messages.
@@ -203,11 +202,11 @@ export class Storage extends EventEmitter<StorageEvents> implements AbstractSupe
     processStorageMessage(this, createInflightMessage(this, [sourceName], message));
   };
 
-  addSubscriber(listener: Sink, filter: Array<Subscription>) {
+  addSubscriber<M: Message>(listener: Sink<M>, filter: SubscriberMap<M>) {
     this._subscribers.push({ listener, filter });
   };
 
-  removeSubscriber(listener: Sink) {
+  removeSubscriber(listener: Sink<any>) {
     const { _subscribers } = this;
 
     for(let i = 0; i < _subscribers.length; i++) {
@@ -434,36 +433,33 @@ export function processInstanceMessages(storage: Storage, instance: Supervisor, 
     for(let i = 0; i < currentLimit; i++) {
       const currentInflight = inflight[i];
       const { _message: m } = currentInflight;
+      const match           = findMatchingSubscription(messageFilter, m, Boolean(currentInflight._received))
 
-      for(let j = 0; j < messageFilter.length; j++) {
-        const currentFilter: Subscription = messageFilter[j];
-
-        if(subscriptionMatches(currentFilter, m, Boolean(currentInflight._received))) {
-          if( ! subscriptionIsPassive(currentFilter)) {
-            currentInflight._received = sourcePath;
-          }
-
-          storage.emit("messageMatched", m, sourcePath, subscriptionIsPassive(currentFilter));
-
-          const updateRequest = update(instance._data, m);
-
-          if(updateHasData(updateRequest)) {
-            const data     = updateStateData(updateRequest);
-            const outgoing = updateOutgoingMessages(updateRequest);
-
-            instance._data = data;
-
-            storage.emit("stateNewData", data, sourcePath, m);
-            instance.emit("stateNewData", data, sourcePath, m);
-
-            enqueueMessages(storage, sourcePath, inflight, outgoing);
-
-            messageFilter = subscriptions(instance._data);
-          }
+      if(match) {
+        if( ! match.isPassive) {
+          currentInflight._received = sourcePath;
         }
 
-        // No Match
+        storage.emit("messageMatched", m, sourcePath, match.isPassive);
+
+        const updateRequest = update(instance._data, m);
+
+        if(updateHasData(updateRequest)) {
+          const data     = updateStateData(updateRequest);
+          const outgoing = updateOutgoingMessages(updateRequest);
+
+          instance._data = data;
+
+          storage.emit("stateNewData", data, sourcePath, m);
+          instance.emit("stateNewData", data, sourcePath, m);
+
+          enqueueMessages(storage, sourcePath, inflight, outgoing);
+
+          messageFilter = subscriptions(instance._data);
+        }
       }
+
+        // No Match
     }
 
     instance = instance._supervisor;
@@ -481,20 +477,16 @@ function processStorageMessage(storage: Storage, inflight: InflightMessage) {
 
   for(let i = 0; i < s.length; i++) {
     const { listener, filter } = s[i];
+    const match                = findMatchingSubscription(filter, _message, Boolean(received));
 
-    // TODO: Split
-    for(let j = 0; j < filter.length; j++) {
-      const currentFilter = filter[j];
-
-      if(subscriptionMatches(currentFilter, _message, Boolean(received))) {
-        if( ! subscriptionIsPassive(currentFilter)) {
-          received = true;
-        }
-
-        storage.emit("messageMatched", _message, [], subscriptionIsPassive(currentFilter));
-
-        listener(_message, _source);
+    if(match) {
+      if( ! match.isPassive) {
+        received = true;
       }
+
+      storage.emit("messageMatched", _message, [], match.isPassive);
+
+      listener(_message, _source);
     }
   }
 

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type { Message
-            , SubscriberMap } from "../src/message";
+            , SubscriptionMap } from "../src/message";
 
 import ninos            from "ninos";
 import ava              from "ava";
@@ -16,10 +16,10 @@ type BMessage = { tag: string, foo: boolean };
 (({ tag: "a" }: AMessage): Message);
 (({ tag: "b", foo: true }: BMessage): Message);
 
-(({ a: true }): SubscriberMap<AMessage>);
-(({ b: true }): SubscriberMap<AMessage | BMessage>);
+(({ a: true }): SubscriptionMap<AMessage>);
+(({ b: true }): SubscriptionMap<AMessage | BMessage>);
 // $ExpectError
-(({ c: true }): SubscriberMap<AMessage>);
+(({ c: true }): SubscriptionMap<AMessage>);
 
 test("findMatchingSubscription() ", t => {
   t.deepEqual(findMatchingSubscription({}, { tag: "a" }, false), null);

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -1,12 +1,11 @@
 /* @flow */
 
-import type { Message } from "../src/message";
+import type { Message
+            , SubscriberMap } from "../src/message";
 
 import ninos            from "ninos";
 import ava              from "ava";
-import { subscribe
-       , subscriptionMatches
-       , subscriptionIsPassive } from "../src/message";
+import { findMatchingSubscription } from "../src/message";
 
 const test = ninos(ava);
 
@@ -17,6 +16,23 @@ type BMessage = { tag: string, foo: boolean };
 (({ tag: "a" }: AMessage): Message);
 (({ tag: "b", foo: true }: BMessage): Message);
 
+(({ a: true }): SubscriberMap<AMessage>);
+(({ b: true }): SubscriberMap<AMessage | BMessage>);
+// $ExpectError
+(({ c: true }): SubscriberMap<AMessage>);
+
+test("findMatchingSubscription() ", t => {
+  t.deepEqual(findMatchingSubscription({}, { tag: "a" }, false), null);
+  t.deepEqual(findMatchingSubscription({ b: true }, { tag: "a" }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, false), { isPassive: false });
+  t.deepEqual(findMatchingSubscription({}, { tag: "a" }, true), null);
+  t.deepEqual(findMatchingSubscription({ b: true }, { tag: "a" }, true), null);
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, true), null);
+});
+
+test.todo("More tests for findMatchingSubscription");
+
+/*
 test("subscribe() creates a subscription", t => {
   t.deepEqual(subscribe("a"), subscribe("a"));
   t.notDeepEqual(subscribe("a"), subscribe("b"));
@@ -67,3 +83,4 @@ test("subscribe() with condition matches only when condition is true", t => {
   t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: true},  true),  false);
   t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: false}, true),  false);
 })
+*/

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -24,63 +24,49 @@ type BMessage = { tag: string, foo: boolean };
 test("findMatchingSubscription() ", t => {
   t.deepEqual(findMatchingSubscription({}, { tag: "a" }, false), null);
   t.deepEqual(findMatchingSubscription({ b: true }, { tag: "a" }, false), null);
-  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, false), { isPassive: false });
   t.deepEqual(findMatchingSubscription({}, { tag: "a" }, true), null);
   t.deepEqual(findMatchingSubscription({ b: true }, { tag: "a" }, true), null);
   t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, true), null);
 });
 
-test.todo("More tests for findMatchingSubscription");
+test("findMatchingSubscription() is active by default", t => {
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, false), { isPassive: false });
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, true), null);
+});
 
-/*
-test("subscribe() creates a subscription", t => {
-  t.deepEqual(subscribe("a"), subscribe("a"));
-  t.notDeepEqual(subscribe("a"), subscribe("b"));
-})
+test("findMatchingSubscription() matches exact message name", t => {
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "a" }, false), { isPassive: false });
+  t.deepEqual(findMatchingSubscription({ a: true }, { tag: "b" }, false), null);
+});
 
-test("subscribe() is active by default", t => {
-  t.is(subscriptionIsPassive(subscribe("a")), false);
-  t.is(subscriptionIsPassive(subscribe("a", true)), true);
-})
+test("findMatchingSubscription() matches received messages if they are passive", t => {
+  t.deepEqual(findMatchingSubscription({ a: { passive: true } }, { tag: "a" }, false), { isPassive: true });
+  t.deepEqual(findMatchingSubscription({ a: { passive: true } }, { tag: "a" }, true), { isPassive: true });
+  t.deepEqual(findMatchingSubscription({ a: { passive: true } }, { tag: "b" }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { passive: true } }, { tag: "b" }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { passive: false } }, { tag: "a" }, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { passive: false } }, { tag: "b" }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { passive: false } }, { tag: "b" }, false), null);
+});
 
-test("subscribe() matches exact message name", t => {
-  t.is(subscriptionMatches(subscribe("a"), { tag: "a"}, false), true);
-  t.is(subscriptionMatches(subscribe("a"), { tag: "b"}, false), false);
-})
-
-test("subscribe() with active matches only when not yet received", t => {
-  t.is(subscriptionMatches(subscribe("a"), { tag: "a"}, false), true);
-  t.is(subscriptionMatches(subscribe("a"), { tag: "b"}, false), false);
-  t.is(subscriptionMatches(subscribe("a"), { tag: "a"}, true), false);
-  t.is(subscriptionMatches(subscribe("a"), { tag: "b"}, true), false);
-})
-
-test("subscribe() with passive matches only when not yet received", t => {
-  t.is(subscriptionMatches(subscribe("a", true), { tag: "a"}, false), true);
-  t.is(subscriptionMatches(subscribe("a", true), { tag: "b"}, false), false);
-  t.is(subscriptionMatches(subscribe("a", true), { tag: "a"}, true), true);
-  t.is(subscriptionMatches(subscribe("a", true), { tag: "b"}, true), false);
-})
-
-test("subscribe() with condition matches only when condition is true", t => {
+test("findMatchingSubscription() with a filter", t => {
   // $ExpectError
-  const cond = msg => msg.a;
+  const filter = msg => msg.a;
 
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "a", a: true},  false), true);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "a", a: false}, false), false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "b", a: true},  false), false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "b", a: false}, false), false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "a", a: true},  true),  false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "a", a: false}, true),  false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "b", a: true},  true),  false);
-  t.is(subscriptionMatches(subscribe("a", false, cond), { tag: "b", a: false}, true),  false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "a", a: true},  false), true);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "a", a: false}, false), false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: true},  false), false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: false}, false), false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "a", a: true},  true),  true);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "a", a: false}, true),  false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: true},  true),  false);
-  t.is(subscriptionMatches(subscribe("a", true, cond),  { tag: "b", a: false}, true),  false);
-})
-*/
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "a", a: false}, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "a", a: true }, false), { isPassive: false });
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "a", a: false}, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "a", a: true }, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "a", a: false}, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "a", a: true }, false), { isPassive: true });
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "a", a: false}, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "a", a: true }, true), { isPassive: true });
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "b", a: false}, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "b", a: true }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "b", a: false}, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter } }, { tag: "b", a: true }, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "b", a: false}, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "b", a: true }, false), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "b", a: false}, true), null);
+  t.deepEqual(findMatchingSubscription({ a: { filter, passive: true } }, { tag: "b", a: true }, true), null);
+});

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -11,7 +11,6 @@ import test             from "ava";
 import { NONE
        , updateData
        , updateAndSend } from "../src/update";
-import { subscribe } from "../src/message";
 
 // Type tests
 type MyMessage = { tag: "a" } | { tag: "b" };
@@ -19,7 +18,7 @@ type MyMessage = { tag: "a" } | { tag: "b" };
   name: "test",
   init: () => updateData("init"),
   update: (data, msg) => NONE,
-  subscriptions: () => [],
+  subscriptions: () => ({}),
 }: State<string, void, MyMessage>);
 
 
@@ -28,11 +27,11 @@ test("State can be instantiated", t => {
     name: "test",
     init: () => updateData("init"),
     update: (data, msg) => updateData(msg.tag),
-    subscriptions: () => [subscribe("any")],
+    subscriptions: () => ({ any: true }),
   };
 
   t.deepEqual(definition.init(), updateData("init"));
   t.deepEqual(definition.update("init", { tag: "foo" }), updateData("foo"));
-  t.deepEqual(definition.subscriptions("init"), [subscribe("any")]);
-  t.deepEqual(definition.subscriptions("foo"), [subscribe("any")]);
+  t.deepEqual(definition.subscriptions("init"), { any: true });
+  t.deepEqual(definition.subscriptions("foo"), { any: true });
 });

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2,8 +2,7 @@
 
 import type { Init
             , State
-            , StateUpdate
-            , Subscriptions } from "../src/state";
+            , StateUpdate } from "../src/state";
 import type { Message } from "../src/message";
 
 import ninos            from "ninos";
@@ -18,7 +17,7 @@ type MyMessage = { tag: "a" } | { tag: "b" };
   name: "test",
   init: () => updateData("init"),
   update: (data, msg) => NONE,
-  subscriptions: () => ({}),
+  subscribe: () => ({}),
 }: State<string, void, MyMessage>);
 
 
@@ -27,11 +26,11 @@ test("State can be instantiated", t => {
     name: "test",
     init: () => updateData("init"),
     update: (data, msg) => updateData(msg.tag),
-    subscriptions: () => ({ any: true }),
+    subscribe: () => ({ any: true }),
   };
 
   t.deepEqual(definition.init(), updateData("init"));
   t.deepEqual(definition.update("init", { tag: "foo" }), updateData("foo"));
-  t.deepEqual(definition.subscriptions("init"), { any: true });
-  t.deepEqual(definition.subscriptions("foo"), { any: true });
+  t.deepEqual(definition.subscribe("init"), { any: true });
+  t.deepEqual(definition.subscribe("foo"), { any: true });
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -912,7 +912,7 @@ test("Storage updates subscriptions during processing when state data is updated
     name: "a",
     init: t.context.stub(() => updateData(false)),
     update: t.context.stub(() => updateData(true)),
-    subscriptions: t.context.stub(s => s ? [subscribe("b")] : [subscribe("a")]),
+    subscriptions: t.context.stub(s => s ? { b: true } : { a: true }),
   };
 
   const emit  = t.context.spy(s, "emit");


### PR DESCRIPTION
Made the subscribers function return a map of message tag -> subscription settings to make it possible to type the update function.

```javascript
type MyMessage = { tag: "a" };

const MyState: State<void, void, MyMessage> = {
  init: ...,
  update: ...,
  subscribe: () => ({ b: true }), // type error since MyMessage does not allow a tag "b"
};
```

This also carries over to the `addSubscriber` method.